### PR TITLE
Add missing dependency serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ regex = "1"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
 scraper = "0.13"
 anyhow = "1"
+serde_json = "1.0"


### PR DESCRIPTION
Adds the `serde_json` crate to Cargo.toml to fix the compilation failure.
<img width="793" alt="image" src="https://github.com/user-attachments/assets/4bb66f3c-f7f2-4fdf-a470-143f5c0318ad" />
